### PR TITLE
NEW: Add new config option for path alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "tidy": "pkg-tidy"
   },
   "devDependencies": {
-    "@stayradiated/pkg": "4.6.0"
+    "@stayradiated/pkg": "4.6.0",
+    "@types/node": "^18.7.17"
   }
 }

--- a/src/exists.ts
+++ b/src/exists.ts
@@ -1,23 +1,69 @@
-import path from 'path'
+import path from "path"
 
 type Node = {
   arguments: readonly {
-    value: string,
-  }[],
+    value: string
+  }[]
   callee: {
-    name: string,
-  },
+    name: string
+  }
   source: {
-    value: string,
-  },
+    value: string
+  }
 }
 
 type Context = {
-  getFilename: () => string,
-  report: (node: Node, message: string, options: {}) => void,
+  getFilename: () => string
+  report: (node: Node, message: string, options: {}) => void
+  options: [Settings]
 }
 
-const getCurrentDirectory = (context: Context) => {
+type Settings = {
+  resolve?: {
+    [key: string]: string
+  }
+}
+
+const defaultSettings = {}
+
+const getSettings = (context: Context): Context["options"][0] => {
+  if (context && context.options && typeof context.options[0] === "object") {
+    return { ...defaultSettings, ...context.options[0] }
+  }
+
+  return defaultSettings
+}
+
+const applyResolve = (
+  resolve: NonNullable<Settings["resolve"]>,
+  context: Context,
+  absPath: string
+) => {
+  if (!absPath.includes("~")) {
+    return absPath
+  }
+  const entries = Object.entries(resolve)
+  for (const mapping of entries) {
+    const [testRx, alias] = mapping
+    const rx = new RegExp(testRx)
+    if (rx.test(absPath)) {
+      const replaced = absPath.replace(rx, alias)
+      const resolved = path.relative(
+        path.dirname(context.getFilename()),
+        replaced
+      )
+      // path.relative doesn't add the ./ prefix for peers or descendants
+      if (!resolved.startsWith(".")) {
+        return `./${resolved}`
+      }
+      return resolved
+    }
+  }
+
+  return absPath
+}
+
+const getCurrentDirectory = (context: Context, node: Node) => {
   let filename = context.getFilename()
   if (!path.isAbsolute(filename)) {
     filename = path.join(process.cwd(), filename)
@@ -27,30 +73,34 @@ const getCurrentDirectory = (context: Context) => {
 }
 
 const testRequirePath = (fileName: string, node: Node, context: Context) => {
-  if (fileName.endsWith('.css') === false) {
+  if (fileName.endsWith(".css") === false) {
     return
   }
-
-  const currentDir = getCurrentDirectory(context)
+  let resolvedFile = fileName
+  const currentDir = getCurrentDirectory(context, node)
+  const settings = getSettings(context)
+  if (settings.resolve) {
+    resolvedFile = applyResolve(settings.resolve, context, resolvedFile)
+  }
 
   try {
-    require.resolve(fileName, { paths: [currentDir] })
+    require.resolve(resolvedFile, { paths: [currentDir] })
   } catch (e) {
-    context.report(node, `Cannot find module: ${fileName}`, {})
+    context.report(node, `Cannot find module: ${resolvedFile}`, {})
   }
 }
 
 const exists = (context: Context) => {
   return {
-    ImportDeclaration (node: Node) {
+    ImportDeclaration(node: Node) {
       testRequirePath(node.source.value, node, context)
     },
 
-    CallExpression (node: Node) {
+    CallExpression(node: Node) {
       if (
-        node.callee.name !== 'require' ||
+        node.callee.name !== "require" ||
         !node.arguments.length ||
-        typeof node.arguments[0].value !== 'string' ||
+        typeof node.arguments[0].value !== "string" ||
         !node.arguments[0].value
       ) {
         return

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { exists } from './exists'
+import { exists } from "./exists"
 
 const rules = {
   exists,
@@ -6,9 +6,14 @@ const rules = {
 
 const configs = {
   recommended: {
-    plugins: ['import-css-path'],
+    plugins: ["import-css-path"],
     rules: {
-      'import-css-path/exists': ['error'],
+      "import-css-path/exists": [
+        "error",
+        {
+          useTypescriptPaths: true,
+        },
+      ],
     },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,6 +129,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
 
+"@types/node@^18.7.17":
+  version "18.7.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.17.tgz#52438111ea98f77475470fc62d79b9eb96bb2c92"
+  integrity sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
This change adds a new config option for path aliasing, as used in Typescript or with Webpack's `resolve.alias`, e.g. resolving `~/path/to/my.module.css` to `app/javascript/src/path/to/my.module.css`. Without this change, the alias isn't resolved and a false positive is surfaced for non-existence.

## Usage

To add the configuration option, we have to bust out of the bundled configuration and use the new `resolve` setting that does basic regex replacement.

```
{
  ...
  plugins: [ "import-css-path" ],
  rules: {
    ...
    "import-css-path/exists": [
      "error",
      {
        resolve: {
          "~/(.*)": "app/javascript/src/$1",
        },
      },
    
  }
```

## Minor changes

Looks like my IDE added some non-essential stylistic changes to the code, including double quotes and adding commas.